### PR TITLE
Update Zig template to Zig 0.15.2

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -6,9 +6,11 @@ pub fn build(b: *std.Build) void {
 
     const exe = b.addExecutable(.{
         .name = "zig-binary",
-        .root_source_file = b.path("src/main.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
 
     b.installArtifact(exe);
@@ -30,8 +32,10 @@ pub fn build(b: *std.Build) void {
     const test_step = b.step("test", "Run unit tests");
     for (test_targets) |test_target| {
         const unit_tests = b.addTest(.{
-            .root_source_file = b.path("src/main.zig"),
-            .target = b.resolveTargetQuery(test_target),
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/main.zig"),
+                .target = b.resolveTargetQuery(test_target),
+            }),
         });
 
         const run_unit_tests = b.addRunArtifact(unit_tests);

--- a/zig/src/main.zig
+++ b/zig/src/main.zig
@@ -1,24 +1,25 @@
 const std = @import("std");
 
 pub fn main() !void {
-    // Prints to stderr (it's a shortcut based on `std.io.getStdErr()`)
+    // Prints to stderr
     std.debug.print("All your {s} are belong to us.\n", .{"codebase"});
 
     // stdout is for the actual output of your application, for example if you
     // are implementing gzip, then only the compressed bytes should be sent to
     // stdout, not any debugging messages.
-    const stdout_file = std.io.getStdOut().writer();
-    var bw = std.io.bufferedWriter(stdout_file);
-    const stdout = bw.writer();
+    var stdout_buffer: [1024]u8 = undefined;
+    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
+    const stdout = &stdout_writer.interface;
 
     try stdout.print("Run `zig build test` to run the tests.\n", .{});
 
-    try bw.flush(); // don't forget to flush!
+    try stdout.flush(); // don't forget to flush!
 }
 
 test "simple test" {
-    var list = std.ArrayList(i32).init(std.testing.allocator);
-    defer list.deinit(); // try commenting this out and see if zig detects the memory leak!
-    try list.append(42);
+    const gpa = std.testing.allocator;
+    var list: std.ArrayList(i32) = .empty;
+    defer list.deinit(gpa); // try commenting this out and see if zig detects the memory leak!
+    try list.append(gpa, 42);
     try std.testing.expectEqual(@as(i32, 42), list.pop());
 }


### PR DESCRIPTION
This PR updates the Zig template so that it works on the latest version of Zig (0.15.2).

I tried to stick closely to the template that already existed, updating it where necessary with the code that's in the official Zig starter template.
The official starter template has a bit more comments in the `build.zig` file and splits the project into an executable and a library, but I don't think that's necessary here.