### PR TITLE
Update Zig template to 0.16 and fix #15

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -5,7 +5,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     const exe = b.addExecutable(.{
-        .name = "zig-binary",
+        .name = "template",
         .root_module = b.createModule(.{
             .root_source_file = b.path("src/main.zig"),
             .target = target,

--- a/zig/src/main.zig
+++ b/zig/src/main.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+
     // Prints to stderr
     std.debug.print("All your {s} are belong to us.\n", .{"codebase"});
 
@@ -8,7 +10,7 @@ pub fn main() !void {
     // are implementing gzip, then only the compressed bytes should be sent to
     // stdout, not any debugging messages.
     var stdout_buffer: [1024]u8 = undefined;
-    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
+    var stdout_writer = std.Io.File.stdout().writer(io, &stdout_buffer);
     const stdout = &stdout_writer.interface;
 
     try stdout.print("Run `zig build test` to run the tests.\n", .{});


### PR DESCRIPTION
Updates the Zig template to build in Zig 0.16 which is now in nixpkgs unstable. Zig 0.16 introduces "juicy main" and requires passing `io` as a parameter to the writer.

Also fixes Issue #15 by renaming the package name in `build.zig` to match `pname` in `flake.nix`.