### PR TITLE
chore: update old wiki links (nixos.wiki -> wiki.nixos.org)

### DIFF
--- a/c/flake.nix
+++ b/c/flake.nix
@@ -16,7 +16,7 @@
     , flake-utils
     , ...
     }:
-    # For more information about the C/C++ infrastructure in nixpkgs: https://nixos.wiki/wiki/C
+    # For more information about the C/C++ infrastructure in nixpkgs: https://wiki.nixos.org/wiki/C
     flake-utils.lib.eachDefaultSystem (system:
     let
       pkgs = nixpkgs.legacyPackages.${system};
@@ -26,7 +26,7 @@
       buildInputs = with pkgs; [
         # add library dependencies here i.e.
         #zlib
-        # Tipp: you can use `nix-locate foo.h` to find the package that provides a header file, see https://github.com/nix-community/nix-index
+        # Tip: you can use `nix-locate foo.h` to find the package that provides a header file, see https://github.com/nix-community/nix-index
       ];
       nativeBuildInputs = with pkgs; [
         # add build dependencies here

--- a/ocaml/flake.nix
+++ b/ocaml/flake.nix
@@ -33,7 +33,7 @@
           # the dune build system
           ocamlPackages.dune_3
 
-          # If you're on NixOS, you'll probably want this (See: https://nixos.wiki/wiki/OCaml#Findlib.2C_ocamlfind)
+          # If you're on NixOS, you'll probably want this (See: https://wiki.nixos.org/wiki/OCaml#Manual_build_with_ocamlc,_findlib,_ocamlfind)
           # ocamlPackages.findlib
 
           # Additionally, add any development packages you want


### PR DESCRIPTION
I'm working on replacing all references to `nixos.wiki` with `wiki.nixos.org` across all repos in https://github.com/nix-community